### PR TITLE
Test Suite and Endpoint Updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: v2.2.4
     hooks:
     -   id: codespell
+        args: ["-L", "nin"]
 -   repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:

--- a/database/synthetic_data.py
+++ b/database/synthetic_data.py
@@ -27,10 +27,10 @@ async def load_synthetic_venues(db_client: AsyncIOMotorDatabase) -> dict[str:dic
     result = await db_client.venues.insert_many(venues)
     log.info(f"Inserted {len(result.inserted_ids)} venues")
 
-    # Map venue documents to IDs
-    ids = [str(id) for id in result.inserted_ids]
-    mapping = {id: venue for id, venue in zip(ids, venues)}
-    return mapping
+    # Reformat ID object
+    for venue in venues:
+        venue["id"] = str(venue.pop("_id"))
+    return venues
 
 
 async def load_synthetic_sessions(
@@ -66,7 +66,7 @@ async def load_synthetic_sessions(
     result = await db_client.sessions.insert_many(sessions)
     log.info(f"Inserted {len(result.inserted_ids)} sessions")
 
-    # Map session documents to IDs
-    ids = [str(id) for id in result.inserted_ids]
-    mapping = {id: session for id, session in zip(ids, sessions)}
-    return mapping
+    # Reformat ID object
+    for session in sessions:
+        session["id"] = str(session.pop("_id"))
+    return sessions

--- a/database/synthetic_data.py
+++ b/database/synthetic_data.py
@@ -6,7 +6,7 @@ from hospo_matcher.utils.data_models import RegionCodes, Session, Venue
 from hospo_matcher.utils.logger import log
 
 
-async def load_synthetic_venues(db_client: AsyncIOMotorDatabase) -> list[str]:
+async def load_synthetic_venues(db_client: AsyncIOMotorDatabase) -> dict[str:dict]:
     """
     Generate and insert synthetic venues into test db.
     """
@@ -26,12 +26,16 @@ async def load_synthetic_venues(db_client: AsyncIOMotorDatabase) -> list[str]:
     # Insert into collection
     result = await db_client.venues.insert_many(venues)
     log.info(f"Inserted {len(result.inserted_ids)} venues")
-    return [str(id) for id in result.inserted_ids]
+
+    # Map venue documents to IDs
+    ids = [str(id) for id in result.inserted_ids]
+    mapping = {id: venue for id, venue in zip(ids, venues)}
+    return mapping
 
 
 async def load_synthetic_sessions(
     db_client: AsyncIOMotorDatabase, venue_ids: list[str]
-) -> list[str]:
+) -> dict[str: dict]:
     """
     Generate and insert synthetic sessions into test db.
     """
@@ -61,4 +65,8 @@ async def load_synthetic_sessions(
     await db_client.sessions.create_index("code", unique=True)
     result = await db_client.sessions.insert_many(sessions)
     log.info(f"Inserted {len(result.inserted_ids)} sessions")
-    return [str(id) for id in result.inserted_ids]
+
+    # Map session documents to IDs
+    ids = [str(id) for id in result.inserted_ids]
+    mapping = {id: session for id, session in zip(ids, sessions)}
+    return mapping

--- a/hospo_matcher/routers/sessions.py
+++ b/hospo_matcher/routers/sessions.py
@@ -14,6 +14,15 @@ async def create_session(session: Session, db: DBClientDep) -> str:
     Create a session document in the database.
     """
     data = session.model_dump(by_alias=True, exclude=["id"])
+
+    # Check if session code already exists
+    existing_session = await db.sessions.find_one({"code": data["code"]})
+    if existing_session:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Code already exists in session with ID - '{str(existing_session['_id'])}'",
+        )
+
     log.info(f"Creating session with data:\n{data}")
     result = await db.sessions.insert_one(data)
     log.info(f"Created session with id {result.inserted_id}")

--- a/hospo_matcher/routers/sessions.py
+++ b/hospo_matcher/routers/sessions.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException, status
 
 from hospo_matcher.utils.data_models import Session, UserVotes
 from hospo_matcher.utils.dependencies import DBClientDep
+from hospo_matcher.utils.helper_functions import str_to_bson_ids
 from hospo_matcher.utils.logger import log
 
 router = APIRouter(prefix="/sessions")
@@ -64,15 +65,7 @@ async def submit_votes(
     session = Session(**session_doc)
 
     # Check that venue IDs are valid BSON ObjectIds before converting
-    venue_bson_ids = []
-    for venue_id in votes.upvotes:
-        if ObjectId.is_valid(venue_id):
-            venue_bson_ids.append(ObjectId(venue_id))
-        else:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                f"Venue ID is not a valid BSON ObjectId - '{venue_id}'",
-            )
+    venue_bson_ids = str_to_bson_ids(votes.upvotes)
 
     # Check that upvoted venues exist
     results = db.venues.find({"_id": {"$in": venue_bson_ids}})

--- a/hospo_matcher/routers/sessions.py
+++ b/hospo_matcher/routers/sessions.py
@@ -64,10 +64,10 @@ async def submit_votes(
     session = Session(**session_doc)
 
     # Check that venue IDs are valid BSON ObjectIds before converting
-    venue_ids = []
+    venue_bson_ids = []
     for venue_id in votes.upvotes:
         if ObjectId.is_valid(venue_id):
-            venue_ids.append(venue_id)
+            venue_bson_ids.append(ObjectId(venue_id))
         else:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
@@ -75,7 +75,7 @@ async def submit_votes(
             )
 
     # Check that upvoted venues exist
-    results = db.venues.find({"_id": {"$in": venue_ids}})
+    results = db.venues.find({"_id": {"$in": venue_bson_ids}})
     matched_venues = await results.to_list(len(votes.upvotes))
     matched_venue_ids = [str(venue["_id"]) for venue in matched_venues]
     invalid_ids = list(votes.upvotes - set(matched_venue_ids))

--- a/hospo_matcher/routers/venues.py
+++ b/hospo_matcher/routers/venues.py
@@ -1,22 +1,31 @@
+from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, status
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
-from hospo_matcher.utils.data_models import Venue
+from hospo_matcher.utils.data_models import Venue, VenueFilters
 from hospo_matcher.utils.database import driver
 from hospo_matcher.utils.logger import log
 from hospo_matcher.utils.dependencies import DBClientDep
 
 router = APIRouter(prefix="/venues")
 
-@router.post(path="/", response_model=list[Venue], response_model_by_alias=False)
-async def read_venues(db:DBClientDep, n: int = 10, query: dict = {}) -> list[Venue]:
+@router.post(path="/sample", response_model=list[Venue], response_model_by_alias=False)
+async def read_venues(db:DBClientDep, filters: VenueFilters) -> list[Venue]:
     """
-    Retrieve a session object by matching code.
+    Retrieve a configurable combination of random venues.
     """
-    log.info(f"Reading {n} venues")
-    result = db.venues.find(query).limit(n)
+    log.info(f"Reading venues:\nExcluding ids:{filters.exclude_ids}\nIncluding ids:{filters.include_ids}")
+    venues = []
 
-    venues = await result.to_list(n)
+    # Retrieve n venues with ID exclusion
+    exclude_ids = [ObjectId(x) for x in filters.exclude_ids]
+    result = db.venues.find({"_id": {"$nin": exclude_ids}}).limit(filters.n)
+    venues.extend(await result.to_list(filters.n))
+
+    # Retrieve included venues
+    include_ids = [ObjectId(x) for x in filters.include_ids]
+    result = db.venues.find({"_id": {"$in": include_ids}})
+    venues.extend(await result.to_list(len(include_ids)))
 
     if not venues:
         raise HTTPException(

--- a/hospo_matcher/routers/venues.py
+++ b/hospo_matcher/routers/venues.py
@@ -17,6 +17,13 @@ async def read_venues(db:DBClientDep, filters: VenueFilters) -> list[Venue]:
     log.info(f"Reading venues:\nExcluding ids:{filters.exclude_ids}\nIncluding ids:{filters.include_ids}")
     venues = []
 
+    # Check for conflicting IDs
+    intersection = list(set(filters.include_ids) & set(filters.exclude_ids))
+    if intersection:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, f"Conflicting filters for ids: {intersection}"
+        )
+
     # Retrieve n venues with ID exclusion
     exclude_ids = [ObjectId(x) for x in filters.exclude_ids]
     result = db.venues.find({"_id": {"$nin": exclude_ids}}).limit(filters.n)

--- a/hospo_matcher/routers/venues.py
+++ b/hospo_matcher/routers/venues.py
@@ -8,7 +8,7 @@ from hospo_matcher.utils.dependencies import DBClientDep
 
 router = APIRouter(prefix="/venues")
 
-@router.get(path="/", response_model=list[Venue], response_model_by_alias=False)
+@router.post(path="/", response_model=list[Venue], response_model_by_alias=False)
 async def read_venues(db:DBClientDep, n: int = 10, query: dict = {}) -> list[Venue]:
     """
     Retrieve a session object by matching code.

--- a/hospo_matcher/routers/venues.py
+++ b/hospo_matcher/routers/venues.py
@@ -55,7 +55,7 @@ async def create_venue(venue: Venue, db: DBClientDep) -> str:
     if existing_venue:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
-            f"Venue already exists - ID {str(existing_venue['_id'])}",
+            f"Venue already exists - ID '{str(existing_venue['_id'])}'",
         )
 
     # Insert venue into db

--- a/hospo_matcher/routers/venues.py
+++ b/hospo_matcher/routers/venues.py
@@ -4,17 +4,20 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 
 from hospo_matcher.utils.data_models import Venue, VenueFilters
 from hospo_matcher.utils.database import driver
-from hospo_matcher.utils.logger import log
 from hospo_matcher.utils.dependencies import DBClientDep
+from hospo_matcher.utils.logger import log
 
 router = APIRouter(prefix="/venues")
 
+
 @router.post(path="/sample", response_model=list[Venue], response_model_by_alias=False)
-async def read_venues(db:DBClientDep, filters: VenueFilters) -> list[Venue]:
+async def read_venues(db: DBClientDep, filters: VenueFilters) -> list[Venue]:
     """
     Retrieve a configurable combination of random venues.
     """
-    log.info(f"Reading venues:\nExcluding ids:{filters.exclude_ids}\nIncluding ids:{filters.include_ids}")
+    log.info(
+        f"Reading venues:\nExcluding ids:{filters.exclude_ids}\nIncluding ids:{filters.include_ids}"
+    )
     venues = []
 
     # Check for conflicting IDs
@@ -35,8 +38,18 @@ async def read_venues(db:DBClientDep, filters: VenueFilters) -> list[Venue]:
     venues.extend(await result.to_list(len(include_ids)))
 
     if not venues:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, "Venues not found."
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Venues not found.")
 
     return venues
+
+
+@router.post(path="/create")
+async def create_session(venue: Venue, db: DBClientDep) -> str:
+    """
+    Create a venue document in the database.
+    """
+    data = venue.model_dump(by_alias=True, exclude=["id"])
+    log.info(f"Creating venue with data:\n{data}")
+    result = await db.venues.insert_one(data)
+    log.info(f"Created venue with id {result.inserted_id}")
+    return str(result.inserted_id)

--- a/hospo_matcher/utils/data_models.py
+++ b/hospo_matcher/utils/data_models.py
@@ -68,7 +68,7 @@ class Venue(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 class VenueFilters(BaseModel):
-    n: int = 10,
+    n: int = 10
     exclude_ids: list[str] = []
     include_ids: list[str] = []
 

--- a/hospo_matcher/utils/data_models.py
+++ b/hospo_matcher/utils/data_models.py
@@ -45,7 +45,7 @@ class UserVotes(BaseModel):
 class Session(BaseModel):
     id: Optional[PyObjectId] = Field(alias="_id", default=None)
     code: str
-    location: RegionCodes = RegionCodes.GreaterWellington
+    location: RegionCodes
     date_time: str = Field(
         default_factory=lambda: datetime.now()
         .astimezone()
@@ -67,9 +67,11 @@ class Venue(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+
 class VenueFilters(BaseModel):
     n: int = 10
     exclude_ids: list[str] = []
     include_ids: list[str] = []
+
 
 settings = Settings()

--- a/hospo_matcher/utils/data_models.py
+++ b/hospo_matcher/utils/data_models.py
@@ -67,5 +67,9 @@ class Venue(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+class VenueFilters(BaseModel):
+    n: int = 10,
+    exclude_ids: list[str] = []
+    include_ids: list[str] = []
 
 settings = Settings()

--- a/hospo_matcher/utils/helper_functions.py
+++ b/hospo_matcher/utils/helper_functions.py
@@ -1,0 +1,22 @@
+"""
+Name this module as helper functions while the scope is not certain.
+"""
+
+from bson import ObjectId
+from fastapi import HTTPException, status
+
+
+def str_to_bson_ids(ids: list[str]) -> list[ObjectId]:
+    """
+    Check that venue IDs are valid BSON ObjectIds and convert to strings.
+    """
+    venue_bson_ids = []
+    for venue_id in ids:
+        if ObjectId.is_valid(venue_id):
+            venue_bson_ids.append(ObjectId(venue_id))
+        else:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"ID is not a valid BSON ObjectId - '{venue_id}'",
+            )
+    return venue_bson_ids

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from httpx import AsyncClient
 from motor.motor_asyncio import AsyncIOMotorDatabase
 from pytest import fixture
+from typing import AsyncGenerator
 
 from database.synthetic_data import load_synthetic_sessions, load_synthetic_venues
 from hospo_matcher.app import app
@@ -54,7 +55,7 @@ async def test_db_client():
 
 
 @pytest.fixture(scope="session")
-async def async_client(test_db_client):
+async def async_client(test_db_client) -> AsyncGenerator[AsyncClient, AsyncClient]:
     """
     API client with overridden db client.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,8 @@ async def synthetic_sessions(
     """
     Generate and insert synthetic sessions into test db.
     """
-    return load_synthetic_sessions(test_db_client, synthetic_venues)
+    venue_ids = list(synthetic_venues.keys())
+    return await load_synthetic_sessions(test_db_client, venue_ids)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ async def synthetic_sessions(
     """
     Generate and insert synthetic sessions into test db.
     """
-    venue_ids = list(synthetic_venues.keys())
+    venue_ids = [venue["id"] for venue in synthetic_venues]
     return await load_synthetic_sessions(test_db_client, venue_ids)
 
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -56,7 +56,7 @@ class TestVotes:
         venue_id_votes = random.sample(venue_id_difference, 5)
 
         # Submit votes
-        body = {"upvotes": venue_id_votes + venue_id_votes}
+        body = {"upvotes": venue_id_votes}
         response = await async_client.post(
             f"/sessions/{session['code']}/{user_id}", json=body
         )
@@ -77,6 +77,16 @@ class TestVotes:
         assert response.status_code == 404
         assert response.json() == {"detail": "Session with code abc not found."}
 
-    async def test_invalid_user_id(self, async_client: AsyncClient):
-        body = {"upvotes": []}
-        response = await async_client.post(f"")
+    async def test_invalid_venue_ids(
+        self, async_client: AsyncClient, synthetic_sessions
+    ):
+        session = synthetic_sessions[0]
+        venue_ids = ["000000000000000000000000", "111111111111111111111111"]
+        body = {"upvotes": venue_ids}
+        response = await async_client.post(
+            f"/sessions/{session['code']}/user_abc", json=body
+        )
+        assert response.status_code == 404
+        assert response.json() == {
+            "detail": f"Venues with IDs not found: {str(venue_ids)}"
+        }

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,11 +1,9 @@
 import random
 
-class TestRead:
-    async def test_read_root(self, async_client):
-        response = await async_client.get("/")
-        assert response.status_code == 200
-        assert response.json() == {"message": "API is running."}
+from httpx import AsyncClient
 
+
+class TestRead:
     async def test_read_valid_session(self, async_client, synthetic_sessions):
         """
         Read a valid session.
@@ -16,9 +14,27 @@ class TestRead:
         response_session = response.json()
         assert response_session == sample_session
 
-    async def test_read_bad_session(self, async_client):
+    async def test_read_invalid_session(self, async_client):
         """
         Read a session that does not exist.
         """
         response = await async_client.get("/sessions/123")
         assert response.status_code == 404
+
+
+class TestCreate:
+    async def test_create_valid_session(self, async_client: AsyncClient):
+        body = {
+            "code": "valid_code",
+            "location": "NZ-AUK",
+        }
+        response = await async_client.post("/sessions/", json=body)
+        assert response.status_code == 200
+
+    async def test_create_invalid_duplicate_code(
+        self, async_client: AsyncClient, synthetic_sessions
+    ):
+        sample_venue = synthetic_sessions[0].copy()
+        body = {"code": sample_venue["code"], "location": sample_venue["location"]}
+        response = await async_client.post("/sessions/", json=body)
+        assert response.status_code == 400

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -71,8 +71,12 @@ class TestVotes:
         db_votes = updated_session["user_votes"][user_id]
         assert local_votes.sort() == db_votes.sort()
 
-    async def test_duplicate_votes(self, async_client: AsyncClient):
-        pass
+    async def test_invalid_code(self, async_client: AsyncClient):
+        body = {"upvotes": []}
+        response = await async_client.post(f"/sessions/abc/user_abc", json=body)
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Session with code abc not found."}
 
     async def test_invalid_user_id(self, async_client: AsyncClient):
-        pass
+        body = {"upvotes": []}
+        response = await async_client.post(f"")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,12 +1,24 @@
+import random
+
 class TestRead:
     async def test_read_root(self, async_client):
         response = await async_client.get("/")
         assert response.status_code == 200
         assert response.json() == {"message": "API is running."}
 
+    async def test_read_valid_session(self, async_client, synthetic_sessions):
+        """
+        Read a valid session.
+        """
+        sample_session = random.choice(synthetic_sessions)
+        response = await async_client.get(f"/sessions/{sample_session['code']}")
+        assert response.status_code == 200
+        response_session = response.json()
+        assert response_session == sample_session
+
     async def test_read_bad_session(self, async_client):
         """
-        Get a session by code that does not exist.
+        Read a session that does not exist.
         """
         response = await async_client.get("/sessions/123")
         assert response.status_code == 404

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -86,10 +86,13 @@ class TestVotes:
         response = await async_client.post(
             f"/sessions/{session['code']}/user_abc", json=body
         )
+
+        # Validate response
         assert response.status_code == 404
-        assert response.json() == {
-            "detail": f"Venues with IDs not found: {str(venue_ids)}"
-        }
+        response_message = response.json()
+        assert str.startswith(response_message["detail"], "Venues with IDs not found: ")
+        for id in venue_ids:
+            assert id in response_message["detail"]
 
     async def test_invalid_bson_ids(
         self, async_client: AsyncClient, synthetic_sessions

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -90,3 +90,17 @@ class TestVotes:
         assert response.json() == {
             "detail": f"Venues with IDs not found: {str(venue_ids)}"
         }
+
+    async def test_invalid_bson_ids(
+        self, async_client: AsyncClient, synthetic_sessions
+    ):
+        session = synthetic_sessions[0]
+        venue_ids = ["abc", "def"]
+        body = {"upvotes": venue_ids}
+        response = await async_client.post(
+            f"/sessions/{session['code']}/user_abc", json=body
+        )
+        assert response.status_code == 400
+        assert response.json() == {
+            "detail": "Venue ID is not a valid BSON ObjectId - 'abc'"
+        }

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 class TestRead:
     async def test_read_valid_session(self, async_client, synthetic_sessions):
         """
-        Read a valid session.
+        Read a session.
         """
         sample_session = random.choice(synthetic_sessions)
         response = await async_client.get(f"/sessions/{sample_session['code']}")
@@ -16,7 +16,7 @@ class TestRead:
 
     async def test_read_invalid_session(self, async_client):
         """
-        Read a session that does not exist.
+        Attempt to read a non-existent session.
         """
         response = await async_client.get("/sessions/123")
         assert response.status_code == 404
@@ -24,6 +24,9 @@ class TestRead:
 
 class TestCreate:
     async def test_create_valid_session(self, async_client: AsyncClient):
+        """
+        Create a session with valid attributes.
+        """
         body = {
             "code": "valid_code",
             "location": "NZ-AUK",
@@ -34,6 +37,9 @@ class TestCreate:
     async def test_create_invalid_duplicate_code(
         self, async_client: AsyncClient, synthetic_sessions
     ):
+        """
+        Attempt to create a session with the same code as another session.
+        """
         sample_venue = synthetic_sessions[0].copy()
         body = {"code": sample_venue["code"], "location": sample_venue["location"]}
         response = await async_client.post("/sessions/", json=body)
@@ -44,6 +50,9 @@ class TestVotes:
     async def test_valid_votes(
         self, async_client: AsyncClient, synthetic_sessions, synthetic_venues
     ):
+        """
+        Submit user votes for new venue IDs.
+        """
         # Get sample session and user id
         session = synthetic_sessions[0]
         user_ids = list(session["user_votes"].keys())
@@ -72,6 +81,9 @@ class TestVotes:
         assert local_votes.sort() == db_votes.sort()
 
     async def test_invalid_code(self, async_client: AsyncClient):
+        """
+        Attempt to submit votes on a non-existent session.
+        """
         body = {"upvotes": []}
         response = await async_client.post(f"/sessions/abc/user_abc", json=body)
         assert response.status_code == 404
@@ -80,6 +92,9 @@ class TestVotes:
     async def test_invalid_venue_ids(
         self, async_client: AsyncClient, synthetic_sessions
     ):
+        """
+        Attempt to vote for non-existent venues.
+        """
         session = synthetic_sessions[0]
         venue_ids = ["000000000000000000000000", "111111111111111111111111"]
         body = {"upvotes": venue_ids}
@@ -97,8 +112,11 @@ class TestVotes:
     async def test_invalid_bson_ids(
         self, async_client: AsyncClient, synthetic_sessions
     ):
+        """
+        Attempt to vote for venues with bad IDs.
+        """
         session = synthetic_sessions[0]
-        venue_ids = ["abc", "def"]
+        venue_ids = ["abc"]
         body = {"upvotes": venue_ids}
         response = await async_client.post(
             f"/sessions/{session['code']}/user_abc", json=body

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,8 +1,12 @@
-async def test_read_root(async_client):
-    response = await async_client.get("/")
-    assert response.status_code == 200
-    assert response.json() == {"message": "API is running."}
+class TestRead:
+    async def test_read_root(self, async_client):
+        response = await async_client.get("/")
+        assert response.status_code == 200
+        assert response.json() == {"message": "API is running."}
 
-async def test_read_sessions(async_client):
-    response = await async_client.get("/sessions/123")
-    assert response.status_code == 404
+    async def test_read_bad_session(self, async_client):
+        """
+        Get a session by code that does not exist.
+        """
+        response = await async_client.get("/sessions/123")
+        assert response.status_code == 404

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -122,6 +122,4 @@ class TestVotes:
             f"/sessions/{session['code']}/user_abc", json=body
         )
         assert response.status_code == 400
-        assert response.json() == {
-            "detail": "Venue ID is not a valid BSON ObjectId - 'abc'"
-        }
+        assert response.json() == {"detail": "ID is not a valid BSON ObjectId - 'abc'"}

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -91,3 +91,25 @@ class TestCreate:
         response = await async_client.post(self.endpoint, json=body)
         result = response.json()
         assert ObjectId(result)
+
+    async def test_create_invalid_empty(self, async_client: AsyncClient):
+        response = await async_client.post(self.endpoint, json={})
+        assert response.status_code == 422
+
+    async def test_create_invalid_hours(self, async_client: AsyncClient):
+        body = {
+            "name": "Invalid Venue Hours",
+            "region": "NZ-AUK",
+            "hour_open": 0,
+            "hour_closed": 25,
+        }
+        response = await async_client.post(self.endpoint, json=body)
+        assert response.status_code == 422
+
+    async def test_create_invalid_duplicate(
+        self, async_client: AsyncClient, synthetic_venues
+    ):
+        sample_venue = synthetic_venues[0].copy()
+        del sample_venue["id"]
+        response = await async_client.post(self.endpoint, json=sample_venue)
+        assert response.status_code == 400

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -4,8 +4,9 @@ from httpx import AsyncClient
 from bson import ObjectId
 
 class TestRead:
+    endpoint = "/venues/sample"
     async def test_read_valid_venues(self, async_client: AsyncClient, synthetic_venues):
-        response = await async_client.get("/venues/")
+        response = await async_client.post(self.endpoint, json={})
         venues = response.json()
         assert response.status_code == 200
         assert len(response.json()) == 10
@@ -13,9 +14,11 @@ class TestRead:
 
     async def test_read_exclude_venues(self, async_client: AsyncClient, synthetic_venues):
         sample_venues = random.sample(synthetic_venues, 10)
-        ids = [ObjectId(venue["id"]) for venue in sample_venues]
-        query = {"id": {"$in": ids}}
-        response = await async_client.post("/venues/", json=query)
+        sample_ids = [venue["id"] for venue in sample_venues]
+        body = {
+            "exclude_ids": sample_ids
+        }
+        response = await async_client.post(self.endpoint, json=body)
         assert response.status_code == 200
         venues = response.json()
-        assert all(venue["id"] not in ids for venue in venues)
+        assert all(venue["id"] not in sample_venues for venue in venues)

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -82,6 +82,18 @@ class TestRead:
         response = await async_client.post(self.endpoint, json=body)
         assert response.status_code == 400
 
+    async def test_read_invalid_bson_id(self, async_client: AsyncClient):
+        """
+        Attempt to include and exclude non-existent venues.
+        """
+        body = {
+            "exclude_ids": ["abc"],
+        }
+        response = await async_client.post(self.endpoint, json=body)
+        assert response.status_code == 400
+        response_message = response.json()
+        assert response_message["detail"] == "ID is not a valid BSON ObjectId - 'abc'"
+
     async def test_read_invalid_ids(self, async_client: AsyncClient):
         """
         Attempt to include and exclude non-existent venues.

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -8,6 +8,9 @@ class TestRead:
     endpoint = "/venues/sample"
 
     async def test_read_valid_venues(self, async_client: AsyncClient, synthetic_venues):
+        """
+        Read a sample of venues.
+        """
         response = await async_client.post(self.endpoint, json={})
         venues = response.json()
         assert response.status_code == 200
@@ -17,6 +20,9 @@ class TestRead:
     async def test_read_exclude_venues(
         self, async_client: AsyncClient, synthetic_venues
     ):
+        """
+        Read venues and apply exclusions.
+        """
         sample_venues = random.sample(synthetic_venues, 10)
         sample_ids = [venue["id"] for venue in sample_venues]
         body = {"exclude_ids": sample_ids}
@@ -28,6 +34,9 @@ class TestRead:
     async def test_read_include_venues(
         self, async_client: AsyncClient, synthetic_venues
     ):
+        """
+        Read venues and apply inclusions.
+        """
         sample_venues = random.sample(synthetic_venues, 10)
         sample_ids = [venue["id"] for venue in sample_venues]
         body = {"include_ids": sample_ids}
@@ -40,6 +49,9 @@ class TestRead:
     async def test_read_exclude_include_venues(
         self, async_client: AsyncClient, synthetic_venues
     ):
+        """
+        Read venues and apply exclusions and inclusions.
+        """
         sample_venues = random.sample(synthetic_venues, 10)
         include_sample_ids = [venue["id"] for venue in sample_venues[5:]]
         exclude_sample_ids = [venue["id"] for venue in sample_venues[:5]]
@@ -58,6 +70,9 @@ class TestRead:
     async def test_read_conflicting_ids_venues(
         self, async_client: AsyncClient, synthetic_venues
     ):
+        """
+        Attempt to include and exclude the same venue.
+        """
         sample_venue = synthetic_venues[0]
         body = {
             "include_ids": [sample_venue["id"]],
@@ -68,6 +83,9 @@ class TestRead:
         assert response.status_code == 400
 
     async def test_read_invalid_ids(self, async_client: AsyncClient):
+        """
+        Attempt to include and exclude non-existent venues.
+        """
         body = {
             "include_ids": ["000000000000000000000000"],
             "exclude_ids": ["111111111111111111111111"],
@@ -82,6 +100,9 @@ class TestCreate:
     endpoint = "venues/create"
 
     async def test_create_valid(self, async_client: AsyncClient):
+        """
+        Create a venue with valid attributes.
+        """
         body = {
             "name": "Valid Venue",
             "region": "NZ-AUK",
@@ -93,10 +114,16 @@ class TestCreate:
         assert ObjectId(result)
 
     async def test_create_invalid_empty(self, async_client: AsyncClient):
+        """
+        Create a venue with an invalid, empty body.
+        """
         response = await async_client.post(self.endpoint, json={})
         assert response.status_code == 422
 
     async def test_create_invalid_hours(self, async_client: AsyncClient):
+        """
+        Attempt to create a venue that violates the hours restriction.
+        """
         body = {
             "name": "Invalid Venue Hours",
             "region": "NZ-AUK",
@@ -109,6 +136,9 @@ class TestCreate:
     async def test_create_invalid_duplicate(
         self, async_client: AsyncClient, synthetic_venues
     ):
+        """
+        Attempt to create a venue that is identical to another.
+        """
         sample_venue = synthetic_venues[0].copy()
         del sample_venue["id"]
         response = await async_client.post(self.endpoint, json=sample_venue)

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -1,6 +1,21 @@
-async def test_read_valid_venues(async_client, synthetic_venues):
-    response = await async_client.get("/venues/")
-    venues = response.json()
-    assert response.status_code == 200
-    assert len(response.json()) == 10
-    assert all(venue in synthetic_venues for venue in venues)
+import random
+
+from httpx import AsyncClient
+from bson import ObjectId
+
+class TestRead:
+    async def test_read_valid_venues(self, async_client: AsyncClient, synthetic_venues):
+        response = await async_client.get("/venues/")
+        venues = response.json()
+        assert response.status_code == 200
+        assert len(response.json()) == 10
+        assert all(venue in synthetic_venues for venue in venues)
+
+    async def test_read_exclude_venues(self, async_client: AsyncClient, synthetic_venues):
+        sample_venues = random.sample(synthetic_venues, 10)
+        ids = [ObjectId(venue["id"]) for venue in sample_venues]
+        query = {"id": {"$in": ids}}
+        response = await async_client.post("/venues/", json=query)
+        assert response.status_code == 200
+        venues = response.json()
+        assert all(venue["id"] not in ids for venue in venues)

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -1,7 +1,6 @@
-from hospo_matcher.utils.logger import log
-
-
-async def test_read_venues(async_client):
+async def test_read_valid_venues(async_client, synthetic_venues):
     response = await async_client.get("/venues/")
+    venues = response.json()
     assert response.status_code == 200
     assert len(response.json()) == 10
+    assert all(venue in synthetic_venues for venue in venues)

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -22,3 +22,45 @@ class TestRead:
         assert response.status_code == 200
         venues = response.json()
         assert all(venue["id"] not in sample_venues for venue in venues)
+
+    async def test_read_include_venues(self, async_client: AsyncClient, synthetic_venues):
+        sample_venues = random.sample(synthetic_venues, 10)
+        sample_ids = [venue["id"] for venue in sample_venues]
+        body = {
+            "include_ids": sample_ids
+        }
+        response = await async_client.post(self.endpoint, json=body)
+        assert response.status_code == 200
+        venues = response.json()
+        result_ids = [venue["id"] for venue in venues]
+        assert all(sample_id in result_ids for sample_id in sample_ids)
+
+    async def test_read_exclude_include_venues(self, async_client: AsyncClient, synthetic_venues):
+        sample_venues = random.sample(synthetic_venues, 10)
+        include_sample_ids = [venue["id"] for venue in sample_venues[5:]]
+        exclude_sample_ids = [venue["id"] for venue in sample_venues[:5]]
+
+        body = {
+            "include_ids": include_sample_ids,
+            "exclude_ids": exclude_sample_ids
+        }
+        response = await async_client.post(self.endpoint, json=body)
+        assert response.status_code == 200
+        venues = response.json()
+        result_ids = [venue["id"] for venue in venues]
+
+        # Validate inclusions
+        assert all(include_id in result_ids for include_id in include_sample_ids)
+        # Validate exclusions
+        assert all(result_id not in exclude_sample_ids for result_id in result_ids)
+        
+
+    async def test_read_conflicting_ids_venues(self, async_client: AsyncClient, synthetic_venues):
+        sample_venue = synthetic_venues[0]
+        body = {
+            "include_ids": [sample_venue["id"]],
+            "exclude_ids": [sample_venue["id"]]
+        }
+
+        response = await async_client.post(self.endpoint, json=body)
+        assert response.status_code == 400

--- a/tests/test_venues.py
+++ b/tests/test_venues.py
@@ -1,10 +1,12 @@
 import random
 
-from httpx import AsyncClient
 from bson import ObjectId
+from httpx import AsyncClient
+
 
 class TestRead:
     endpoint = "/venues/sample"
+
     async def test_read_valid_venues(self, async_client: AsyncClient, synthetic_venues):
         response = await async_client.post(self.endpoint, json={})
         venues = response.json()
@@ -12,38 +14,37 @@ class TestRead:
         assert len(response.json()) == 10
         assert all(venue in synthetic_venues for venue in venues)
 
-    async def test_read_exclude_venues(self, async_client: AsyncClient, synthetic_venues):
+    async def test_read_exclude_venues(
+        self, async_client: AsyncClient, synthetic_venues
+    ):
         sample_venues = random.sample(synthetic_venues, 10)
         sample_ids = [venue["id"] for venue in sample_venues]
-        body = {
-            "exclude_ids": sample_ids
-        }
+        body = {"exclude_ids": sample_ids}
         response = await async_client.post(self.endpoint, json=body)
         assert response.status_code == 200
         venues = response.json()
         assert all(venue["id"] not in sample_venues for venue in venues)
 
-    async def test_read_include_venues(self, async_client: AsyncClient, synthetic_venues):
+    async def test_read_include_venues(
+        self, async_client: AsyncClient, synthetic_venues
+    ):
         sample_venues = random.sample(synthetic_venues, 10)
         sample_ids = [venue["id"] for venue in sample_venues]
-        body = {
-            "include_ids": sample_ids
-        }
+        body = {"include_ids": sample_ids}
         response = await async_client.post(self.endpoint, json=body)
         assert response.status_code == 200
         venues = response.json()
         result_ids = [venue["id"] for venue in venues]
         assert all(sample_id in result_ids for sample_id in sample_ids)
 
-    async def test_read_exclude_include_venues(self, async_client: AsyncClient, synthetic_venues):
+    async def test_read_exclude_include_venues(
+        self, async_client: AsyncClient, synthetic_venues
+    ):
         sample_venues = random.sample(synthetic_venues, 10)
         include_sample_ids = [venue["id"] for venue in sample_venues[5:]]
         exclude_sample_ids = [venue["id"] for venue in sample_venues[:5]]
 
-        body = {
-            "include_ids": include_sample_ids,
-            "exclude_ids": exclude_sample_ids
-        }
+        body = {"include_ids": include_sample_ids, "exclude_ids": exclude_sample_ids}
         response = await async_client.post(self.endpoint, json=body)
         assert response.status_code == 200
         venues = response.json()
@@ -53,14 +54,40 @@ class TestRead:
         assert all(include_id in result_ids for include_id in include_sample_ids)
         # Validate exclusions
         assert all(result_id not in exclude_sample_ids for result_id in result_ids)
-        
 
-    async def test_read_conflicting_ids_venues(self, async_client: AsyncClient, synthetic_venues):
+    async def test_read_conflicting_ids_venues(
+        self, async_client: AsyncClient, synthetic_venues
+    ):
         sample_venue = synthetic_venues[0]
         body = {
             "include_ids": [sample_venue["id"]],
-            "exclude_ids": [sample_venue["id"]]
+            "exclude_ids": [sample_venue["id"]],
         }
 
         response = await async_client.post(self.endpoint, json=body)
         assert response.status_code == 400
+
+    async def test_read_invalid_ids(self, async_client: AsyncClient):
+        body = {
+            "include_ids": ["000000000000000000000000"],
+            "exclude_ids": ["111111111111111111111111"],
+        }
+        response = await async_client.post(self.endpoint, json=body)
+        result_venues = response.json()
+        assert response.status_code == 200
+        assert len(result_venues) == 10
+
+
+class TestCreate:
+    endpoint = "venues/create"
+
+    async def test_create_valid(self, async_client: AsyncClient):
+        body = {
+            "name": "Valid Venue",
+            "region": "NZ-AUK",
+            "hour_open": 10,
+            "hour_closed": 22,
+        }
+        response = await async_client.post(self.endpoint, json=body)
+        result = response.json()
+        assert ObjectId(result)


### PR DESCRIPTION
## Synthetic Data
Synthetic venues and sessions are programmatically created and written to a DB from the `database/` dir.

## Sessions Tests
- Valid and invalid read requests
- Valid and invalid create requests
- Valid and invalid submit votes requests

## Venues Tests
- Valid and invalid read requests
- Valid and invalid create requests

Creating the tests highlighted cases that need to be handled. The associated changes are as follow:

# Other Changes
1. Added a check to the create session endpoint for an existing, matching code.
2. Added a check to the submit votes endpoint to ensure venues exist.
3. Read venues endpoint:
  A. Add filters to exclude certain IDs
  B. Add filter to include certain IDs
  C. Check and handle conflicting inclusion and exclusion ids.
4. Check if venue already exists in create venue endpoint.
5. 
6. Whitelisted the string "nin" for codespell as it appears in MongoDB queries.
7. Added conversion handling from strings to BSON `ObjectIds` as it can cause an exception. Raises an `HTTPException 400` if invalid strings are supplied.