### PR TITLE
Archive meetups to comply with API policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "hospo-matcher",
       "dependencies": {
+        "dotenv": "^16.4.7",
         "mongodb": "^6.11.0",
         "netlify-cli": "^17.37.2"
       }
@@ -41,6 +42,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/memory-pager": {
@@ -106,9 +119,9 @@
       }
     },
     "node_modules/netlify-cli": {
-      "version": "17.37.2",
-      "resolved": "https://registry.npmjs.org/netlify-cli/-/netlify-cli-17.37.2.tgz",
-      "integrity": "sha512-jA3wijrcr4Y8NF44sTQmR/4k6QPQwoK9Vf6vKimTJ1xyGASt+Mg+iWXyg1NsmKxWs5EUnS7yuWFZJ2eb/FWyMQ==",
+      "version": "17.38.1",
+      "resolved": "https://registry.npmjs.org/netlify-cli/-/netlify-cli-17.38.1.tgz",
+      "integrity": "sha512-9R7KYIJac0FPbgCgIG3UuBZB2QMmSBBMygAUfRzTjT6PLOYS6xVLAlmO4/upVdSu//gREimPLlKaYVNiH2lUqQ==",
       "hasInstallScript": true,
       "hasShrinkwrap": true,
       "license": "MIT",
@@ -116,13 +129,15 @@
         "@bugsnag/js": "7.25.0",
         "@fastify/static": "7.0.4",
         "@netlify/blobs": "8.1.0",
-        "@netlify/build": "29.56.0",
-        "@netlify/build-info": "7.15.2",
-        "@netlify/config": "20.19.0",
-        "@netlify/edge-bundler": "12.2.3",
-        "@netlify/edge-functions": "2.9.0",
+        "@netlify/build": "29.58.0",
+        "@netlify/build-info": "7.17.0",
+        "@netlify/config": "20.21.0",
+        "@netlify/edge-bundler": "12.3.1",
+        "@netlify/edge-functions": "2.11.1",
+        "@netlify/headers-parser": "7.3.0",
         "@netlify/local-functions-proxy": "1.1.1",
-        "@netlify/zip-it-and-ship-it": "9.41.1",
+        "@netlify/redirect-parser": "14.5.0",
+        "@netlify/zip-it-and-ship-it": "9.42.1",
         "@octokit/rest": "20.1.1",
         "@opentelemetry/api": "1.8.0",
         "ansi-escapes": "7.0.0",
@@ -134,7 +149,7 @@
         "boxen": "7.1.1",
         "chalk": "5.3.0",
         "chokidar": "3.6.0",
-        "ci-info": "4.0.0",
+        "ci-info": "4.1.0",
         "clean-deep": "3.4.0",
         "commander": "10.0.1",
         "comment-json": "4.2.5",
@@ -146,12 +161,12 @@
         "debug": "4.3.7",
         "decache": "4.6.2",
         "dot-prop": "9.0.0",
-        "dotenv": "16.4.5",
+        "dotenv": "16.4.7",
         "env-paths": "3.0.0",
         "envinfo": "7.14.0",
         "etag": "1.8.1",
         "execa": "5.1.1",
-        "express": "4.21.1",
+        "express": "4.21.2",
         "express-logging": "1.1.1",
         "extract-zip": "2.0.1",
         "fastest-levenshtein": "1.0.16",
@@ -189,13 +204,11 @@
         "maxstache": "1.0.7",
         "maxstache-stream": "1.0.4",
         "multiparty": "4.2.3",
-        "netlify": "13.1.21",
-        "netlify-headers-parser": "7.1.4",
-        "netlify-redirect-parser": "14.3.0",
+        "netlify": "13.2.0",
         "netlify-redirector": "0.5.0",
         "node-fetch": "3.3.2",
         "node-version-alias": "3.4.1",
-        "ora": "8.1.0",
+        "ora": "8.1.1",
         "p-filter": "4.1.0",
         "p-map": "7.0.2",
         "p-wait-for": "5.0.2",
@@ -236,40 +249,11 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.0.tgz",
+      "integrity": "sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
+        "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
@@ -277,61 +261,29 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/netlify-cli/node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
+    "node_modules/netlify-cli/node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "engines": {
-        "node": ">=4"
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/netlify-cli/node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
+    "node_modules/netlify-cli/node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=6.9.0"
       }
     },
     "node_modules/netlify-cli/node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+      "version": "7.26.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.1.tgz",
+      "integrity": "sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -340,13 +292,12 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@babel/types": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1208,22 +1159,22 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/build": {
-      "version": "29.56.0",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-29.56.0.tgz",
-      "integrity": "sha512-x2DUxBt1MigjAX+2xpDmWKp4BlTvg4GofaR2SWSz80D+zkfWRJp01de1O5mKH9QK3saQBQUVJyi+mrK64YNf4w==",
+      "version": "29.58.0",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-29.58.0.tgz",
+      "integrity": "sha512-aLFJTQtP7uwoFUzq5IPLRL3Zy8FTyvW0MfHRzzV7jku416uOAcLXy9EkvpJcuvXpqvTsuKBlF553Jirz2UlNRw==",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/blobs": "^7.4.0",
-        "@netlify/cache-utils": "^5.1.6",
-        "@netlify/config": "^20.19.0",
-        "@netlify/edge-bundler": "12.2.3",
-        "@netlify/framework-info": "^9.8.13",
-        "@netlify/functions-utils": "^5.2.93",
-        "@netlify/git-utils": "^5.1.1",
-        "@netlify/opentelemetry-utils": "^1.2.1",
+        "@netlify/cache-utils": "^5.2.0",
+        "@netlify/config": "^20.21.0",
+        "@netlify/edge-bundler": "12.3.1",
+        "@netlify/framework-info": "^9.9.0",
+        "@netlify/functions-utils": "^5.3.1",
+        "@netlify/git-utils": "^5.2.0",
+        "@netlify/opentelemetry-utils": "^1.3.0",
         "@netlify/plugins-list": "^6.80.0",
-        "@netlify/run-utils": "^5.1.1",
-        "@netlify/zip-it-and-ship-it": "9.41.1",
+        "@netlify/run-utils": "^5.2.0",
+        "@netlify/zip-it-and-ship-it": "9.42.1",
         "@sindresorhus/slugify": "^2.0.0",
         "ansi-escapes": "^6.0.0",
         "chalk": "^5.0.0",
@@ -1233,7 +1184,7 @@
         "figures": "^5.0.0",
         "filter-obj": "^5.0.0",
         "got": "^12.0.0",
-        "hot-shots": "10.1.1",
+        "hot-shots": "10.2.1",
         "indent-string": "^5.0.0",
         "is-plain-obj": "^4.0.0",
         "js-yaml": "^4.0.0",
@@ -1288,9 +1239,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/build-info": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-7.15.2.tgz",
-      "integrity": "sha512-z249vRTIyeO1Coaa2UaaZJpTN2D9mE0HPvuQfVknJ+WqHdLjPHlmaKu2HyekfnA5zE8mVSkPAJsP9dip3kySSg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-7.17.0.tgz",
+      "integrity": "sha512-503ES8SfLMkWQyBs41YCoWOLJWmcgcBZXfdtltz/jPSFaFXdpzlhq/CV3W9uHnKgLG/MBkEtTlBRtzy5weHKVw==",
       "dependencies": {
         "@bugsnag/js": "^7.20.0",
         "@iarna/toml": "^2.2.5",
@@ -1386,9 +1337,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/build-info/node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -1713,9 +1664,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/cache-utils": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-5.1.6.tgz",
-      "integrity": "sha512-0K1+5umxENy9H3CC+v5qGQbeTmKv/PBAhOxPKK6GPykOVa7OxT26KGMU7Jozo6pVNeLPJUvCCMw48ycwtQ1fvw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-5.2.0.tgz",
+      "integrity": "sha512-kKzGQ9gKNRUjqFMC1/1goeTe1WfzL6KhphwXac7tialowg10Dtmr2X+eDzfH9enGvD6vhYR4a0QMTQWkjfPVmg==",
       "dependencies": {
         "cpy": "^9.0.0",
         "get-stream": "^6.0.0",
@@ -1768,11 +1719,13 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/config": {
-      "version": "20.19.0",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-20.19.0.tgz",
-      "integrity": "sha512-vkqTQ7jaudPSRME6ZzYml6qRWxIJXnUQ8csqOSx5Yv0ysj1zb2l+Ke3c5bc6Cttkg4ay2YLx4M0/7n6nT3KojQ==",
+      "version": "20.21.0",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-20.21.0.tgz",
+      "integrity": "sha512-3t2IcYcaGIYagESXK7p4I0GOahlTxhR/UCgRdNKkv0ihIgYLW4CEmZXGHytyXYU55Ismbyt5W7EJ+Qi4fVy6VA==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
+        "@netlify/headers-parser": "^7.3.0",
+        "@netlify/redirect-parser": "^14.5.0",
         "chalk": "^5.0.0",
         "cron-parser": "^4.1.0",
         "deepmerge": "^4.2.2",
@@ -1786,9 +1739,7 @@
         "is-plain-obj": "^4.0.0",
         "js-yaml": "^4.0.0",
         "map-obj": "^5.0.0",
-        "netlify": "^13.1.21",
-        "netlify-headers-parser": "^7.1.4",
-        "netlify-redirect-parser": "^14.3.0",
+        "netlify": "^13.2.0",
         "node-fetch": "^3.3.1",
         "omit.js": "^2.0.2",
         "p-locate": "^6.0.0",
@@ -2020,12 +1971,12 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/edge-bundler": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-12.2.3.tgz",
-      "integrity": "sha512-o/Od4gvGT2qPSjJ1TSh8KYDJHfzxW4iemA5DiZtXIDgaIvWgvehZKDROp9wJ2FseP2F83y4ZDmt5xFfBSD9IYQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-12.3.1.tgz",
+      "integrity": "sha512-Kmg7+OD/5PWyWUNDR7G6DyyL/+kliN8JcSe2vaZ6zmPWdK/+ejeCA+d/9ROOEMsAvX7heuwe74SA301Mp9ESaw==",
       "dependencies": {
         "@import-maps/resolve": "^1.0.1",
-        "@vercel/nft": "^0.27.0",
+        "@vercel/nft": "0.27.7",
         "ajv": "^8.11.2",
         "ajv-errors": "^3.0.0",
         "better-ajv-errors": "^1.2.0",
@@ -2480,9 +2431,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/edge-bundler/node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw=="
     },
     "node_modules/netlify-cli/node_modules/@netlify/edge-bundler/node_modules/find-up": {
       "version": "6.3.0",
@@ -2607,14 +2558,14 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/edge-functions": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.9.0.tgz",
-      "integrity": "sha512-W1kdwLpvUlhfI2FTOe6SEcoobW7Fw+Vm9WN5Gwb5lTCG6QXBE3gpCZk+NVQ4p/XoOcXYwWAS5pfOTMKUoYNQnA=="
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.11.1.tgz",
+      "integrity": "sha512-pyQOTZ8a+ge5lZlE+H/UAHyuqQqtL5gE0pXrHT9mOykr3YQqnkB2hZMtx12odatZ87gHg4EA+UPyMZUbLfnXvw=="
     },
     "node_modules/netlify-cli/node_modules/@netlify/framework-info": {
-      "version": "9.8.13",
-      "resolved": "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-9.8.13.tgz",
-      "integrity": "sha512-ZZXCggokY/y5Sz93XYbl/Lig1UAUSWPMBiQRpkVfbrrkjmW2ZPkYS/BgrM2/MxwXRvYhc/TQpZX6y5JPe3quQg==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-9.9.0.tgz",
+      "integrity": "sha512-ucPBnBJVJUjsoCAhFy76zjQgg2hLPaR1jTOjH5W/jglc5DIZ9HJSgHfTp4e9A3ok8GXvQyTrYKE5kTZpwLoYQQ==",
       "dependencies": {
         "ajv": "^8.12.0",
         "filter-obj": "^5.0.0",
@@ -2624,7 +2575,7 @@
         "p-filter": "^3.0.0",
         "p-locate": "^6.0.0",
         "process": "^0.11.10",
-        "read-pkg-up": "^9.1.0",
+        "read-package-up": "^11.0.0",
         "semver": "^7.3.8"
       },
       "engines": {
@@ -2742,11 +2693,11 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/functions-utils": {
-      "version": "5.2.93",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-5.2.93.tgz",
-      "integrity": "sha512-/b2JtJuB3KNN5AIfiH/tan/uM4i6nLj2QFGUL9oID58cMsd73iouRacKu4ct+gxUU78y+/6fiOeYRXbcthdltA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-5.3.1.tgz",
+      "integrity": "sha512-Bm1Uro1Uql21/PUKcpGcBv88e5qd3fRHSmO9FM/uE1HxtsuujXer1pRTE/+qZRnPXpeLLtWwda7a3zIfADOEaw==",
       "dependencies": {
-        "@netlify/zip-it-and-ship-it": "9.41.1",
+        "@netlify/zip-it-and-ship-it": "9.42.1",
         "cpy": "^9.0.0",
         "path-exists": "^5.0.0"
       },
@@ -2763,9 +2714,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/git-utils": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-5.1.1.tgz",
-      "integrity": "sha512-oyHieuTZH3rKTmg7EKpGEGa28IFxta2oXuVwpPJI/FJAtBje3UE+yko0eDjNufgm3AyGa8G77trUxgBhInAYuw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-5.2.0.tgz",
+      "integrity": "sha512-maNQyhQ6zTS5Kwl03HXoUa7uTNjmCvZea5Jko2pyDWz0xW1cunnil+4s33wXrMZJNDvyv97O2vkC5N1sAS3fyQ==",
       "dependencies": {
         "execa": "^6.0.0",
         "map-obj": "^5.0.0",
@@ -2874,6 +2825,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/headers-parser": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/headers-parser/-/headers-parser-7.3.0.tgz",
+      "integrity": "sha512-4RTR9X3bylRV+q1/OHSwXcXylYKr5+3mkKcL/QLBI+bTqvSO82vjWAQAqQfvWVSCaF6HrYORid3zLGzJ94YOSw==",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "escape-string-regexp": "^5.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "is-plain-obj": "^4.0.0",
+        "map-obj": "^5.0.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/headers-parser/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/headers-parser/node_modules/map-obj": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.2.tgz",
+      "integrity": "sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/headers-parser/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/local-functions-proxy": {
@@ -3084,17 +3081,17 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/open-api": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-2.34.0.tgz",
-      "integrity": "sha512-C4v7Od/vnGgZ1P4JK3Fn9uUi9HkTxeUqUtj4OLnGD+rGyaVrl4JY89xMCoVksijDtO8XylYFU59CSTnQNeNw7g==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-2.35.0.tgz",
+      "integrity": "sha512-c6LpV29CKMgq6/eViItE6L2ova9UldBO9tHRvvwpJfSBgCwWaFhmiepe07E3xIW4GfTCGoWE816mNzXB/2ceZg==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/opentelemetry-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@netlify/opentelemetry-utils/-/opentelemetry-utils-1.2.1.tgz",
-      "integrity": "sha512-A6nQBvUn/avHQopLOOjX8rY2eua//jufbx4NZZODACEHtfXAEmOjCoDe2m+cQPRq+jNa98nvCy/sJh2RwuCQog==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/opentelemetry-utils/-/opentelemetry-utils-1.3.0.tgz",
+      "integrity": "sha512-2LpNZpowo7Q4nSNmPYcx4gAAXIhRiSanX7Bux7b0D7ohdaC8NOgmFc7vdVzIsCChLwqbQ4HZpN1fd0W40Cm7bg==",
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3110,10 +3107,33 @@
         "node": "^14.14.0 || >=16.0.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/@netlify/redirect-parser": {
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/redirect-parser/-/redirect-parser-14.5.0.tgz",
+      "integrity": "sha512-0HxtPj+azmoaQhuZAbyTn6WyMl+PO6XrFU6TRo/0b57jtVz9uTjrvFytjmTqTvVEY1sLePCxbTbgEULm2XDTjQ==",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "fast-safe-stringify": "^2.1.1",
+        "filter-obj": "^5.0.0",
+        "is-plain-obj": "^4.0.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@netlify/redirect-parser/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@netlify/run-utils": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-5.1.1.tgz",
-      "integrity": "sha512-V2B8ZB19heVKa715uOeDkztxLH7uaqZ+9U5fV7BRzbQ2514DO5Vxj9hG0irzuRLfZXZZjp/chPUesv4VVsce/A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-5.2.0.tgz",
+      "integrity": "sha512-bsrv7Sjge5g71VMgZ65Ioc5q4lHXdLQCmpUU6sY06Aeol1psi1iDOGVMx/7ExJjbCtQgxye35wZjAz60i6X22Q==",
       "dependencies": {
         "execa": "^6.0.0"
       },
@@ -3202,15 +3222,15 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/zip-it-and-ship-it": {
-      "version": "9.41.1",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-9.41.1.tgz",
-      "integrity": "sha512-EzXw1+4OJ4mCZUOqVPDQZNM8jf/563utFo1Ph6dYtSR21E1oYlgt6Oib1pyG/bFGufvdtrxw845/1MTCPvXzJA==",
+      "version": "9.42.1",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-9.42.1.tgz",
+      "integrity": "sha512-ZCGM2OnLbiFOZO+kpODI6BKjH6X4a6vE/tJd0aqIvKWiygZgxhIw5APZUzgwLGv4BahIBG+tcfKgW7krpZYLwA==",
       "dependencies": {
         "@babel/parser": "^7.22.5",
-        "@babel/types": "7.25.6",
+        "@babel/types": "7.26.3",
         "@netlify/binary-info": "^1.0.0",
-        "@netlify/serverless-functions-api": "^1.31.0",
-        "@vercel/nft": "^0.27.1",
+        "@netlify/serverless-functions-api": "^1.31.1",
+        "@vercel/nft": "0.27.7",
         "archiver": "^7.0.0",
         "common-path-prefix": "^3.0.0",
         "cp-file": "^10.0.0",
@@ -3249,9 +3269,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/zip-it-and-ship-it/node_modules/@netlify/serverless-functions-api": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.31.0.tgz",
-      "integrity": "sha512-/ux3fefmw0yGmzRMOqhGrzbAuALtW8HY08bjE4yCk+y8CzB9r9mPd1ApSJe3KlYD+sqDvbQGrEXdifQ/LzUIDQ==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.31.1.tgz",
+      "integrity": "sha512-SkNxzfCwctS5ETnCqJOJfZZ/jB0pTkbWEAsApHoL7HzUQGWoRM6wYf4baJAJVMTfZBQu534SbKuwRs7WDAs43A==",
       "dependencies": {
         "@netlify/node-cookies": "^0.1.0",
         "urlpattern-polyfill": "8.0.2"
@@ -3951,16 +3971,244 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
+      "integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
       "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.4.tgz",
+      "integrity": "sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.4.tgz",
+      "integrity": "sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.4.tgz",
+      "integrity": "sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.4.tgz",
+      "integrity": "sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.4.tgz",
+      "integrity": "sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.4.tgz",
+      "integrity": "sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.4.tgz",
+      "integrity": "sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.4.tgz",
+      "integrity": "sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.4.tgz",
+      "integrity": "sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.4.tgz",
+      "integrity": "sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.4.tgz",
+      "integrity": "sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
+      "integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.4.tgz",
+      "integrity": "sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.4.tgz",
+      "integrity": "sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.4.tgz",
+      "integrity": "sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.4.tgz",
+      "integrity": "sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@sindresorhus/is": {
       "version": "5.6.0",
@@ -4090,6 +4338,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
     "node_modules/netlify-cli/node_modules/@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -4157,11 +4410,11 @@
       "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/netlify-cli/node_modules/@types/normalize-package-data": {
@@ -4214,12 +4467,12 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@vercel/nft": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.27.2.tgz",
-      "integrity": "sha512-7LeioS1yE5hwPpQfD3DdH04tuugKjo5KrJk3yK5kAI3Lh76iSsK/ezoFQfzuT08X3ZASQOd1y9ePjLNI9+TxTQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.27.7.tgz",
+      "integrity": "sha512-FG6H5YkP4bdw9Ll1qhmbxuE8KwW2E/g8fJpM183fWQLeVDGqzeywMIeJ9h2txdWZ03psgWMn6QymTxaDLmdwUg==",
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.5",
-        "@rollup/pluginutils": "^4.0.0",
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "@rollup/pluginutils": "^5.1.3",
         "acorn": "^8.6.0",
         "acorn-import-attributes": "^1.9.5",
         "async-sema": "^3.1.1",
@@ -4227,7 +4480,7 @@
         "estree-walker": "2.0.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.8",
         "node-gyp-build": "^4.2.2",
         "resolve-from": "^5.0.0"
       },
@@ -5585,9 +5838,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/ci-info": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
-      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
       "funding": [
         {
           "type": "github",
@@ -5659,6 +5912,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^2.0.0"
       },
@@ -6460,9 +6714,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7021,9 +7275,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "engines": {
         "node": ">=12"
       },
@@ -7349,9 +7603,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7372,7 +7626,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -7387,6 +7641,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/netlify-cli/node_modules/express-logging": {
@@ -7443,6 +7701,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/netlify-cli/node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/netlify-cli/node_modules/express/node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -8608,9 +8871,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/hot-shots": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-10.1.1.tgz",
-      "integrity": "sha512-KTsH9hb+YZHH0IIRf22y0X8mPw8j521W5xRAUeaUlGNBDsf44ixE7ZeyXbUHd/nQ1n04UEhi2ja05/QVOS/CgQ==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-10.2.1.tgz",
+      "integrity": "sha512-tmjcyZkG/qADhcdC7UjAp8D7v7W2DOYFgaZ48fYMuayMQmVVUg8fntKmrjes/b40ef6yZ+qt1lB8kuEDfLC4zw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8825,6 +9088,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
       "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -8947,6 +9211,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -8995,6 +9260,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -9014,6 +9280,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -9022,6 +9289,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "license": "MIT",
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -9034,6 +9302,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
       "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -9042,6 +9311,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^3.0.0"
       },
@@ -10757,7 +11027,8 @@
     "node_modules/netlify-cli/node_modules/mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ=="
+      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+      "license": "ISC"
     },
     "node_modules/netlify-cli/node_modules/nan": {
       "version": "2.17.0",
@@ -10801,11 +11072,11 @@
       "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw=="
     },
     "node_modules/netlify-cli/node_modules/netlify": {
-      "version": "13.1.21",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-13.1.21.tgz",
-      "integrity": "sha512-PLw+IskyiY+GZNvheR0JgBXIuwebKowY/JU1QBArnXT5Tza1cFbSRr2LJVdiAJCvtbYY73CapfJeSMp36nRjjQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-13.2.0.tgz",
+      "integrity": "sha512-kOBfGlg3EMCjMLIBYjg0geMZaqzL75gg3bAuarjtj+/66zxbhh5qF6ZNQs+Tcq2MT3oJXG3ENKVNdnuvD1i5ag==",
       "dependencies": {
-        "@netlify/open-api": "^2.34.0",
+        "@netlify/open-api": "^2.35.0",
         "lodash-es": "^4.17.21",
         "micro-api-client": "^3.3.0",
         "node-fetch": "^3.0.0",
@@ -10815,75 +11086,6 @@
       },
       "engines": {
         "node": "^14.16.0 || >=16.0.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/netlify-headers-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/netlify-headers-parser/-/netlify-headers-parser-7.1.4.tgz",
-      "integrity": "sha512-fTVQf8u65vS4YTP2Qt1K6Np01q3yecRKXf6VMONMlWbfl5n3M/on7pZlZISNAXHNOtnVt+6Kpwfl+RIeALC8Kg==",
-      "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "escape-string-regexp": "^5.0.0",
-        "fast-safe-stringify": "^2.0.7",
-        "is-plain-obj": "^4.0.0",
-        "map-obj": "^5.0.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.16.0 || >=16.0.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/netlify-headers-parser/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/netlify-headers-parser/node_modules/map-obj": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.2.tgz",
-      "integrity": "sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/netlify-headers-parser/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/netlify-redirect-parser": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-14.3.0.tgz",
-      "integrity": "sha512-/Oqq+SrTXk8hZqjCBy0AkWf5qAhsgcsdxQA09uYFdSSNG5w9rhh17a7dp77o5Q5XoHCahm8u4Kig/lbXkl4j2g==",
-      "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "fast-safe-stringify": "^2.1.1",
-        "filter-obj": "^5.0.0",
-        "is-plain-obj": "^4.0.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.16.0 || >=16.0.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/netlify-redirect-parser/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/netlify-cli/node_modules/netlify-redirector": {
@@ -11287,9 +11489,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/ora": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.1.0.tgz",
-      "integrity": "sha512-GQEkNkH/GHOhPFXcqZs3IDahXEQcQxsSjEkK4KvEEST4t7eNzoMjxTzef+EZ+JluDEV+Raoi3WQ2CflnRdSVnQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.1.1.tgz",
+      "integrity": "sha512-YWielGi1XzG1UTvOaCFaNgEnuhZVMSHYkW/FQ7UX8O26PtlpdM84c0f7wLPlkvx2RfiQmnzd61d/MGxmpQeJPw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^5.0.0",
@@ -11529,9 +11731,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/p-timeout": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
-      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.3.tgz",
+      "integrity": "sha512-UJUyfKbwvr/uZSV6btANfb+0t/mOhKV/KXcCUTp8FcQI+v/0d+wXqH4htrW0E4rR6WiEO/EPvUFiV9D5OI4vlw==",
       "engines": {
         "node": ">=14.16"
       },
@@ -11695,11 +11897,6 @@
       "engines": {
         "node": "14 || >=16.14"
       }
-    },
-    "node_modules/netlify-cli/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
     },
     "node_modules/netlify-cli/node_modules/path-type": {
       "version": "4.0.0",
@@ -12380,62 +12577,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/netlify-cli/node_modules/read-pkg-up": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-      "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-      "dependencies": {
-        "find-up": "^6.3.0",
-        "read-pkg": "^7.1.0",
-        "type-fest": "^2.5.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-      "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/read-pkg-up/node_modules/read-pkg": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-      "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.1",
-        "normalize-package-data": "^3.0.2",
-        "parse-json": "^5.2.0",
-        "type-fest": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/netlify-cli/node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -12640,6 +12781,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "license": "MIT",
       "dependencies": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -12652,6 +12794,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -12660,6 +12803,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^1.0.0"
       },
@@ -12701,6 +12845,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/rollup": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
+      "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.22.4",
+        "@rollup/rollup-android-arm64": "4.22.4",
+        "@rollup/rollup-darwin-arm64": "4.22.4",
+        "@rollup/rollup-darwin-x64": "4.22.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.22.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.22.4",
+        "@rollup/rollup-linux-arm64-musl": "4.22.4",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.22.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.22.4",
+        "@rollup/rollup-linux-x64-gnu": "4.22.4",
+        "@rollup/rollup-linux-x64-musl": "4.22.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.22.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.22.4",
+        "@rollup/rollup-win32-x64-msvc": "4.22.4",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/netlify-cli/node_modules/run-async": {
@@ -13716,14 +13896,6 @@
         "node": ">=8.17.0"
       }
     },
-    "node_modules/netlify-cli/node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/netlify-cli/node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -13949,9 +14121,9 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "node_modules/netlify-cli/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "node_modules/netlify-cli/node_modules/unenv": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "dotenv": "^16.4.7",
     "mongodb": "^6.11.0",
     "netlify-cli": "^17.37.2"
   }

--- a/scripts/archive_meetups.mjs
+++ b/scripts/archive_meetups.mjs
@@ -1,0 +1,68 @@
+import "dotenv/config"; // Load environment variables from .env
+import { MongoClient } from "mongodb";
+
+const uri = process.env.MONGODB_URI;
+const dbName = process.env.MONGODB_DATABASE;
+const sourceCollection = process.env.MONGODB_ARCHIVE_SOURCE_COLLECTION;
+const targetCollection = process.env.MONGODB_ARCHIVE_TARGET_COLLECTION;
+
+const client = new MongoClient(uri);
+
+async function archiveOldRecords(window = 7, startDate = new Date()) {
+    try {
+        await client.connect();
+        const db = client.db(dbName);
+
+        // Calculate cutoff date by subtracting the window from the start date
+        const cutoffDate = new Date(startDate);
+        cutoffDate.setDate(cutoffDate.getDate() - window);
+
+        // Find documents older than the cutoff date
+        const documentsToArchive = await db.collection(sourceCollection)
+            .find({ created_datetime: { $lt: cutoffDate } })
+            .toArray();
+
+        if (documentsToArchive.length === 0) {
+            console.log("No records to archive.");
+            return;
+        }
+
+        let modifiedCount = 0;
+
+        // Process documents to remove place_id locations
+        const processedDocuments = documentsToArchive.map(doc => {
+            if (doc.user_locations) {
+                Object.keys(doc.user_locations).forEach(userId => {
+                    doc.user_locations[userId] = doc.user_locations[userId].map(location => {
+                        if ("place_id" in location) {
+                            modifiedCount++;
+                            return { id: location.id }; // Keep only id key
+                        }
+                        return location;
+                    });
+                });
+            }
+            return doc;
+        });
+
+        // Insert processed documents into the archive collection
+        await db.collection(targetCollection).insertMany(processedDocuments);
+
+        // Delete archived documents from source collection
+        await db.collection(sourceCollection).deleteMany({ created_datetime: { $lt: cutoffDate } });
+
+        console.log(`Archived ${documentsToArchive.length} documents.`);
+        console.log(`Modified ${modifiedCount} location records by removing place_id, latitude, and longitude.`);
+
+    } catch (error) {
+        console.error("Error during archiving:", error);
+    } finally {
+        await client.close();
+    }
+}
+
+// Example usage with default values
+archiveOldRecords().catch(console.error);
+
+// Example usage with custom window and start date
+// archiveOldRecords(10, new Date("2025-03-01")).catch(console.error);


### PR DESCRIPTION
Created a script to archive old meetups and comply with Google Maps API policies.

In the source collection, meetups older than n (default 7) days are stripped of their cached Maps API data, written to the target collection, and deleted from the source collection.

The only remaining latitude and longitude data is from coordinates that have been provided from the devices Navigator Geolocation class.