### PR TITLE
Disable current location on pac selection

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -23,6 +23,9 @@ placeAutocomplete.addEventListener("gmp-placeselect", async ({ place }) => {
         fields: ["location"],
     });
 
+    // Disable other location input button
+    dom.elements.getLocationBtn.disabled = true;
+
     // Trigger input processing
     await processLocationInput(place.location.lat(), place.location.lng(), place.id)
 });

--- a/js/main.js
+++ b/js/main.js
@@ -19,15 +19,16 @@ const placeAutocomplete = dom.initializeAutocomplete();
 
 // Get Place coordinates on selection, and display the results.
 placeAutocomplete.addEventListener("gmp-placeselect", async ({ place }) => {
+    // Disable other location input button
+    dom.elements.getLocationBtn.disabled = true;
+
     await place.fetchFields({
         fields: ["location"],
     });
 
-    // Disable other location input button
-    dom.elements.getLocationBtn.disabled = true;
-
     // Trigger input processing
     await processLocationInput(place.location.lat(), place.location.lng(), place.id)
+    dom.elements.getLocationBtn.disabled = false;
 });
 
 // Load current user's browser data


### PR DESCRIPTION
Fixed issue where user could click current location input during delay after selecting places autocomplete result. Now, the element is disabled before location processing begins.